### PR TITLE
update crowdsec dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/crowdsecurity/go-cs-bouncer
 go 1.20
 
 require (
-	github.com/crowdsecurity/crowdsec v1.5.4
+	github.com/crowdsecurity/crowdsec v1.5.4-final
 	github.com/prometheus/client_golang v1.15.1
 	github.com/sirupsen/logrus v1.9.3
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/crowdsecurity/crowdsec v1.5.4 h1:pHwkqyLdyMCJ/0AM71sAWbwgUMP5cgN3pwjy+iAKYDg=
-github.com/crowdsecurity/crowdsec v1.5.4/go.mod h1:PCiubBn1mthcc1S3leNpIS4yvykMTH/2X9z92HUeHes=
+github.com/crowdsecurity/crowdsec v1.5.4-final h1:Z9i+cPfteYjIpaV3ZZQvEmC2nhPNgYwtO/2SJsdr0To=
+github.com/crowdsecurity/crowdsec v1.5.4-final/go.mod h1:PCiubBn1mthcc1S3leNpIS4yvykMTH/2X9z92HUeHes=
 github.com/crowdsecurity/go-cs-lib v0.0.4 h1:mH3iqz8H8iH9YpldqCdojyKHy9z3JDhas/k6I8M0ims=
 github.com/crowdsecurity/go-cs-lib v0.0.4/go.mod h1:8FMKNGsh3hMZi2SEv6P15PURhEJnZV431XjzzBSuf0k=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
the 1.5.4 tag was moved after pre-release so we
depend on 1.5.4-final to make sure builds won't break without the global cache