### PR TITLE
return system certs if capath is not configured

### DIFF
--- a/tls.go
+++ b/tls.go
@@ -9,17 +9,6 @@ import (
 )
 
 func getCertPool(caPath string, logger logrus.FieldLogger) (*x509.CertPool, error) {
-	if caPath == "" {
-		return nil, nil //nolint: nilnil
-	}
-
-	logger.Infof("Using CA cert '%s'", caPath)
-
-	caCert, err := os.ReadFile(caPath)
-	if err != nil {
-		return nil, fmt.Errorf("unable to load CA certificate '%s': %w", caPath, err)
-	}
-
 	cp, err := x509.SystemCertPool()
 	if err != nil {
 		return nil, fmt.Errorf("unable to load system CA certificates: %w", err)
@@ -27,6 +16,17 @@ func getCertPool(caPath string, logger logrus.FieldLogger) (*x509.CertPool, erro
 
 	if cp == nil {
 		cp = x509.NewCertPool()
+	}
+
+	if caPath == "" {
+		return cp, nil
+	}
+
+	logger.Infof("Using CA cert '%s'", caPath)
+
+	caCert, err := os.ReadFile(caPath)
+	if err != nil {
+		return nil, fmt.Errorf("unable to load CA certificate '%s': %w", caPath, err)
 	}
 
 	cp.AppendCertsFromPEM(caCert)


### PR DESCRIPTION
fix https://github.com/crowdsecurity/go-cs-bouncer/issues/36