### PR TITLE
Expand variables in bouncer configs

### DIFF
--- a/live_bouncer.go
+++ b/live_bouncer.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/crowdsecurity/crowdsec/pkg/apiclient"
 	"github.com/crowdsecurity/crowdsec/pkg/models"
+
+	"github.com/crowdsecurity/go-cs-lib/csstring"
 )
 
 type LiveBouncer struct {
@@ -43,7 +45,9 @@ func (b *LiveBouncer) ConfigReader(configReader io.Reader) error {
 		return fmt.Errorf("unable to read configuration: %w", err)
 	}
 
-	err = yaml.Unmarshal(content, b)
+	data := csstring.StrictExpand(string(content), os.LookupEnv)
+
+	err = yaml.Unmarshal([]byte(data), b)
 	if err != nil {
 		return fmt.Errorf("unable to unmarshal config file: %w", err)
 	}

--- a/stream_bouncer.go
+++ b/stream_bouncer.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/crowdsecurity/crowdsec/pkg/apiclient"
 	"github.com/crowdsecurity/crowdsec/pkg/models"
+
+	"github.com/crowdsecurity/go-cs-lib/csstring"
 )
 
 var TotalLAPIError = prometheus.NewCounter(prometheus.CounterOpts{
@@ -65,7 +67,9 @@ func (b *StreamBouncer) ConfigReader(configReader io.Reader) error {
 		return fmt.Errorf("unable to read configuration: %w", err)
 	}
 
-	err = yaml.Unmarshal(content, b)
+	data := csstring.StrictExpand(string(content), os.LookupEnv)
+
+	err = yaml.Unmarshal([]byte(data), b)
 	if err != nil {
 		return fmt.Errorf("unable to unmarshal config file: %w", err)
 	}


### PR DESCRIPTION
This commit changes the behavior of how bouncers read configuration files by expanding variables from the environment in a similar to how the main [crowdsec engine behaves ](https://docs.crowdsec.net/docs/configuration/crowdsec_configuration/#environment-variables)

I am in the process of building a [NixOS](https://nixos.org) modules that runs crowdsec on NixOS machines.
Generally speaking, NixOS machines are designed to be immutable. Because of that, configuration files, eg. the bouncers `config.yaml` cannot be edited in place.
In addition, immutable files on the nix store are currently world readable due to technical limitations of the system.
This poses a challenge whenever a modules requires "secrets", like the crowdsec LAPI key the bouncer uses for registration.

This change would make it easier to deal with this challenge, as a module could simply source the API key from a secure, potentially mutable location, eg. a `Vault` instance, in the startup script and simply providing it via the environment.