### PR TITLE
enhance: Handle unix prefix on scheme

### DIFF
--- a/client.go
+++ b/client.go
@@ -78,5 +78,10 @@ func getAPIClient(urlstr string, userAgent string, apiKey string, caPath string,
 		}
 	}
 
+	if apiURL.Scheme == "unix" {
+		// We reset the scheme here because NewDefaultClient expects the url as a path
+		apiURL.Scheme = ""
+	}
+
 	return apiclient.NewDefaultClient(apiURL, "v1", userAgent, client)
 }


### PR DESCRIPTION
Fix: #44 

Since we use the same apic as CrowdSec the support already existed, we just need to handle when a user supplies "unix:/path/to/file" simply we just set the scheme to be an empty string.